### PR TITLE
feat(endpoints): adds GET filtered list and GET by id endpoints

### DIFF
--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -8,3 +8,37 @@ exports.create = (payload) => {
     return new Movie({ id: movie.id }).fetch();
   });
 };
+
+exports.findAll = (query) => {
+  return new Movie()
+  .query((qb) => {
+    if (query.title) {
+      qb.where('title', '=', query.title);
+    }
+
+    if (query.release_year) {
+      if (query.release_year.eq) {
+        qb.where('release_year', '=', query.release_year.eq)
+      }
+
+      if (query.release_year.lt) {
+        qb.where('release_year', '<', query.release_year.lt)
+      }
+
+      if (query.release_year.gt) {
+        qb.where('release_year', '>', query.release_year.gt)
+      }
+    }
+
+  })
+  .orderBy('title', 'release_year')
+  .fetchAll();
+};
+
+exports.findById = (id) => {
+  return new Movie()
+  .query((qb) => {
+    qb.where('id', '=', id);
+  })
+  .fetch();
+};

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -1,7 +1,9 @@
 'use strict';
 
-const Controller      = require('./controller')
-const MovieValidator  = require('../../../validators/movie');
+const Controller         = require('./controller')
+const MovieValidator     = require('../../../validators/movie');
+const MovieListValidator = require('../../../validators/movie-list.js');
+const MovieIdValidator   = require('../../../validators/movie-id.js');
 
 exports.register = (server, options, next) => {
 
@@ -14,6 +16,32 @@ exports.register = (server, options, next) => {
       },
       validate: {
         payload: MovieValidator
+      }
+    }
+  },
+
+  {
+    method: 'GET',
+    path: '/movies',
+    config: {
+      handler: (request, reply) => {
+        reply(Controller.findAll(request.query));
+      },
+      validate: {
+        query: MovieListValidator
+      }
+    }
+  },
+
+  {
+    method: 'GET',
+    path: '/movies/{id}',
+    config: {
+      handler: (request, reply) => {
+        reply(Controller.findById(request.params.id));
+      },
+      validate: {
+        params: MovieIdValidator
       }
     }
   }]);

--- a/lib/validators/movie-id.js
+++ b/lib/validators/movie-id.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const Joi = require('joi');
+
+module.exports = Joi.object().keys({
+  id: Joi.number().integer().required()
+});

--- a/lib/validators/movie-list.js
+++ b/lib/validators/movie-list.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const Joi = require('joi');
+
+module.exports = Joi.object().keys({
+  title: Joi.string().min(1).max(255).optional(),
+  release_year: Joi.object().keys({
+    eq: Joi.number().integer().min(1878).max(9999).optional(),
+    gt: Joi.number().integer().min(1878).max(9999).optional(),
+    lt: Joi.number().integer().min(1878).max(9999).optional()
+  })
+});

--- a/lib/validators/movie.js
+++ b/lib/validators/movie.js
@@ -4,5 +4,5 @@ const Joi = require('joi');
 
 module.exports = Joi.object().keys({
   title: Joi.string().min(1).max(255).required(),
-  release_year: Joi.number().min(1878).max(9999).optional()
+  release_year: Joi.number().integer().min(1878).max(9999).optional()
 });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -369,7 +369,8 @@
       "dependencies": {
         "esprima": {
           "version": "2.7.2",
-          "from": "esprima@>=2.7.1 <3.0.0"
+          "from": "esprima@2.7.2",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
         },
         "estraverse": {
           "version": "1.9.3",
@@ -2323,6 +2324,11 @@
         }
       }
     },
+    "rosie": {
+      "version": "1.6.0",
+      "from": "rosie@>=1.6.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/rosie/-/rosie-1.6.0.tgz"
+    },
     "run-async": {
       "version": "0.1.0",
       "from": "run-async@>=0.1.0 <0.2.0",
@@ -2452,7 +2458,8 @@
       "dependencies": {
         "hoek": {
           "version": "4.0.1",
-          "from": "hoek@>=4.0.0 <5.0.0"
+          "from": "hoek@4.0.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.0.1.tgz"
         }
       }
     },
@@ -2542,7 +2549,8 @@
       "dependencies": {
         "user-home": {
           "version": "1.1.1",
-          "from": "user-home@>=1.1.1 <2.0.0"
+          "from": "user-home@1.1.1",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "generate-changelog": "^1.0.0",
     "istanbul": "^0.4.2",
     "mocha": "^2.2.5",
-    "nodemon": "^1.9.2"
+    "nodemon": "^1.9.2",
+    "rosie": "^1.6.0"
   }
 }

--- a/test/factories/movie.js
+++ b/test/factories/movie.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const Factory = require('rosie').Factory;
+
+const MovieFactory = new Factory()
+  .sequence('id', (i) => i.toString())
+  .attr('title', 'Title');
+
+module.exports = MovieFactory;

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const Knex = require('../lib/libraries/knex');
+
+beforeEach(() => {
+  return Knex('movies').truncate();
+});

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -1,7 +1,13 @@
 'use strict';
 
-const Controller  = require('../../../../lib/plugins/features/movies/controller');
-const Movie       = require('../../../../lib/models/movie');
+const Controller    = require('../../../../lib/plugins/features/movies/controller');
+const Movie         = require('../../../../lib/models/movie');
+const MovieFactory  = require('../../../../test/factories/movie');
+const Knex          = require('../../../../lib/libraries/knex')
+
+const movieOne  = MovieFactory.build({ title: 'Pulp Fiction', release_year: 1994 });
+const movieTwo  = MovieFactory.build({ title: 'Inglorious Basterds', release_year: 2009 });
+
 
 describe('movie controller', () => {
 
@@ -21,6 +27,83 @@ describe('movie controller', () => {
       });
     });
 
+  });
+
+  describe('findAll', () => {
+
+    beforeEach(() => {
+      return Knex('movies').insert([movieOne, movieTwo]);
+    });
+
+    it('finds all movies', () => {
+      const query = {};
+
+      return Controller.findAll(query)
+      .then((movies) => {
+        expect(movies).to.have.lengthOf(2);
+      });
+    });
+
+    it('finds movies matching title', () => {
+      const query = { title: movieOne.title };
+
+      return Controller.findAll(query)
+      .then((movies) => {
+        expect(movies.models[0].get('title')).to.eql(query.title);
+      });
+    });
+
+    it('finds movies released in release_year', () => {
+      const query = { release_year: { eq: movieTwo.release_year } };
+
+      return Controller.findAll(query)
+      .then((movies) => {
+        expect(movies.models[0].get('release_year')).to.eql(query.release_year.eq);
+      });
+    });
+
+    it('finds movies released before release_year', () => {
+      const query = { release_year: { lt: movieOne.release_year + 1 } };
+
+      return Controller.findAll(query)
+      .then((movies) => {
+        expect(movies.models[0].get('release_year')).to.be.below(query.release_year.lt);
+      });
+    });
+
+    it('finds movies released after release_year', () => {
+      const query = { release_year: { gt: movieTwo.release_year - 1 } };
+
+      return Controller.findAll(query)
+      .then((movies) => {
+        expect(movies.models[0].get('release_year')).to.be.above(query.release_year.gt);
+      });
+    });
+  });
+
+  describe('findById', () => {
+
+    beforeEach(() => {
+      return Knex('movies').insert([movieOne, movieTwo]);
+    })
+
+    it('finds movie by id', () => {
+      const params = { id: 1 };
+
+      return Controller.findById(params.id)
+      .then((movie) => {
+        expect(movie.id).to.eql(params.id);
+      });
+    });
+
+    it('returns nothing if no movie has given id', () => {
+      const params = { id: 0 };
+
+      return Controller.findById(params.id)
+      .then((movie) => {
+        expect(movie).to.not.exist;
+      });
+    })
   });
 
 });

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -1,6 +1,11 @@
 'use strict';
 
 const Movies = require('../../../../lib/server');
+const MovieFactory  = require('../../../../test/factories/movie');
+const Knex          = require('../../../../lib/libraries/knex')
+
+const movieOne  = MovieFactory.build({ title: 'Pulp Fiction', release_year: 1994 });
+const movieTwo  = MovieFactory.build({ title: 'Inglorious Basterds', release_year: 2009 });
 
 describe('movies integration', () => {
 
@@ -18,6 +23,43 @@ describe('movies integration', () => {
       });
     });
 
+  });
+
+  describe('findAll', () => {
+
+    beforeEach(() => {
+      return Knex('movies').insert([movieOne, movieTwo]);
+    });
+
+    it('returns a list of movies', () => {
+      return Movies.inject({
+        url: '/movies',
+        method: 'GET'
+      })
+      .then((response) => {
+        expect(response.statusCode).to.eql(200);
+        expect(response.result).to.have.lengthOf(2);
+      });
+    });
+
+  });
+
+  describe('findById', () => {
+
+    beforeEach(() => {
+      return Knex('movies').insert([movieOne, movieTwo]);
+    });
+
+    it('returns a movie matching given id', () => {
+      return Movies.inject({
+        url: '/movies/3',
+        method: 'GET'
+      })
+      .then((response) => {
+        expect(response.statusCode).to.eql(200);
+        expect(response.result.id).to.eql(3);
+      });
+    });
   });
 
 });

--- a/test/validators/movie-id.test.js
+++ b/test/validators/movie-id.test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const Joi = require('joi');
+
+const MovieIdValidator = require('../../lib/validators/movie-id');
+
+describe('movie id validator', () => {
+
+  describe('id', () => {
+
+    it('is required', () => {
+      const params = {};
+      const result = Joi.validate(params, MovieIdValidator);
+
+      expect(result.error.details[0].path).to.eql('id');
+      expect(result.error.details[0].type).to.eql('any.required');
+    });
+  })
+
+})

--- a/test/validators/movie-list.test.js
+++ b/test/validators/movie-list.test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const Joi = require('joi');
+
+const MovieListValidator = require('../../lib/validators/movie-list');
+
+describe('movie list validator', () => {
+
+  describe('title', () => {
+
+    it('is optional', () => {
+      const query = {};
+      const result = Joi.validate(query, MovieListValidator);
+
+      expect(result.error).to.not.exist;
+    });
+
+    it('is not empty', () => {
+      const query = { title: '' };
+      const result = Joi.validate(query, MovieListValidator);
+
+      expect(result.error.details[0].path).to.eql('title');
+      expect(result.error.details[0].type).to.eql('any.empty');
+    });
+
+    it('is less than 255 characters', () => {
+      const query = { title: 'a'.repeat(260) };
+      const result = Joi.validate(query, MovieListValidator);
+
+      expect(result.error.details[0].path).to.eql('title');
+      expect(result.error.details[0].type).to.eql('string.max');
+    });
+
+  })
+
+  describe('release_year', () => {
+
+    it('is optional', () => {
+      const query = {};
+      const result = Joi.validate(query, MovieListValidator);
+
+      expect(result.error).to.not.exist;
+    });
+
+    it('is after 1878', () => {
+      const query = {
+        title: 'foo',
+        release_year: { eq: 1800 }
+      };
+      const result = Joi.validate(query, MovieListValidator);
+
+      expect(result.error.details[0].path).to.eql('release_year.eq');
+      expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+    it('is limited to 4 digits', () => {
+      const query = {
+        title: 'foo',
+        release_year: { eq: 12345 }
+      };
+      const result = Joi.validate(query, MovieListValidator);
+
+      expect(result.error.details[0].path).to.eql('release_year.eq');
+      expect(result.error.details[0].type).to.eql('number.max');
+    });
+
+  })
+})


### PR DESCRIPTION
What: Creates two new endpoints `GET .../movies` and `GET .../movies/{id}`

Why: Adds ability to return a filtered list of movies by querying the database by movie title and release year. Adds ability to return a movie matching a given id.

Details:
- Wrote `findAll` and `findById` functions in the movies controller file
- Added the two endpoints in the movies index file, handled them with the corresponding function in the controller file
- Wrote validator files `movie-list.js` and `movie-id.js`
- Tested validators, controller functions, and endpoint integration
