### PR TITLE
feat(movies): migration to add name column to movies

### DIFF
--- a/db/migrations/20170825111648_add_name_to_movies.js
+++ b/db/migrations/20170825111648_add_name_to_movies.js
@@ -1,0 +1,19 @@
+'use strict';
+
+exports.up = (Knex, Promise) => {
+  return Knex.schema.table('movies', (table) => {
+    table.text('name');
+  })
+  .then(() => {
+    return Knex.raw('ALTER TABLE movies ALTER COLUMN title DROP NOT NULL');
+  });
+};
+
+exports.down = (Knex, Promise) => {
+  return Knex.schema.table('movies', (table) => {
+    table.dropColumn('name');
+  })
+  .then(() => {
+    return Knex.raw('ALTER TABLE movies ALTER COLUMN title SET NOT NULL');
+  });
+};


### PR DESCRIPTION
What: Adds `name` column to `movies` table and makes `title` nullable